### PR TITLE
Add fully qualified call to Application.launch()

### DIFF
--- a/src/main/groovy/com/mtanevski/prototypes/groovyjavafx/App.groovy
+++ b/src/main/groovy/com/mtanevski/prototypes/groovyjavafx/App.groovy
@@ -30,6 +30,6 @@ class App extends Application {
      * @param args the command line arguments
      */
     static void main(String... args) {
-        launch(App.class, args);
+        Application.launch(App.class, args);
     }
 }


### PR DESCRIPTION
To maximize cross-platform operations, make fully qualified call to Application.launch(). Some environments are very picky about this. I've run into issues on MacOS and Linux-based operating systems in the past.